### PR TITLE
AM-25255 Expose intuit_tid on IdsException for fault responses

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/FaultHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/FaultHandler.cs
@@ -40,6 +40,13 @@ namespace Intuit.Ipp.Core.Rest
     public class FaultHandler
     {
         /// <summary>
+        /// The name of the intuit_tid response header, also used as the key under which it is exposed
+        /// on <see cref="System.Exception.Data"/> so callers can surface Intuit's transaction id when
+        /// reporting failures to Intuit support.
+        /// </summary>
+        public const string IntuitTidExceptionDataKey = "intuit_tid";
+
+        /// <summary>
         /// The Service Context.
         /// </summary>
         private ServiceContext context;
@@ -207,11 +214,26 @@ namespace Intuit.Ipp.Core.Rest
                             idsException = new IdsException(statusCodeDescription, statusCode.ToString(CultureInfo.InvariantCulture), webException.Source);
                             break;
                     }
+
+                    AttachIntuitTid(idsException, response_intuit_tid_header);
                 }
             }
 
             // Return the Ids Exception.
             return idsException;
+        }
+
+        /// <summary>
+        /// Attaches the given intuit_tid value to the exception's <see cref="System.Exception.Data"/>.
+        /// </summary>
+        /// <param name="exception">The exception to enrich.</param>
+        /// <param name="intuitTid">The intuit_tid value.</param>
+        internal static void AttachIntuitTid(IdsException exception, string intuitTid)
+        {
+            if (exception != null && !string.IsNullOrEmpty(intuitTid))
+            {
+                exception.Data[IntuitTidExceptionDataKey] = intuitTid;
+            }
         }
 
         /// <summary>
@@ -237,6 +259,23 @@ namespace Intuit.Ipp.Core.Rest
             idsException = this.IterateFaultAndPrepareException(fault);
 
             // return the exception.
+            return idsException;
+        }
+
+        /// <summary>
+        /// Parses the error response and prepares the exception, attaching the given intuit_tid.
+        /// Used for fault responses returned as HTTP 200 OK with a Fault body (e.g. error 6041),
+        /// where the intuit_tid header is read by the caller from the HttpWebResponse.
+        /// </summary>
+        /// <param name="errorString">The error string.</param>
+        /// <param name="intuitTid">The intuit_tid response header value.</param>
+        /// <returns>Ids Exception.</returns>
+        public IdsException ParseErrorResponseAndPrepareException(string errorString, string intuitTid)
+        {
+            IdsException idsException = this.ParseErrorResponseAndPrepareException(errorString);
+
+            AttachIntuitTid(idsException, intuitTid);
+
             return idsException;
         }
 

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/FaultHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/FaultHandler.cs
@@ -128,15 +128,7 @@ namespace Intuit.Ipp.Core.Rest
                         }
                     }
 
-                    string response_intuit_tid_header = "";
-                    //get intuit_tid header
-                    for (int i = 0; i < errorResponse.Headers.Count; ++i)
-                    {
-                        if (errorResponse.Headers.Keys[i] == "intuit_tid")
-                        {
-                            response_intuit_tid_header = errorResponse.Headers[i];
-                        }
-                    }
+                    string response_intuit_tid_header = errorResponse.Headers[IntuitTidExceptionDataKey] ?? "";
                     //Log errorstring to disk
                     CoreHelper.GetRequestLogging(this.context).LogPlatformRequests(" Response Intuit_Tid header: " + response_intuit_tid_header + ", Response Payload: " + errorString, false);
 
@@ -160,6 +152,7 @@ namespace Intuit.Ipp.Core.Rest
                     if (isIps)
                     {
                         IdsException exception = new IdsException(errorString, statusCode.ToString(CultureInfo.InvariantCulture), webException.Source);
+                        AttachIntuitTid(exception, response_intuit_tid_header);
                         this.context.IppConfiguration.Logger.CustomLogger.Log(TraceLevel.Error, exception.ToString());
                         //CoreHelper.AdvancedLogging.Log(idsException.ToString());
                         return exception;

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
@@ -103,20 +103,22 @@ namespace Intuit.Ipp.Core.Rest
 
             // Create a variable for storing the response.
             string response = string.Empty;
+            // intuit_tid of the response, captured so it can be attached to a fault exception below.
+            string responseIntuitTid = null;
             try
             {
                 // Check whether the retryPolicy is null.
                 if (this.context.IppConfiguration.RetryPolicy == null)
                 {
                     // If yes then call the rest service without retry framework enabled.
-                    response = this.CallRestService(request);
+                    response = this.CallRestService(request, out responseIntuitTid);
                 }
                 else
                 {
                     // If no then call the rest service using the execute action of retry framework.
                     this.context.IppConfiguration.RetryPolicy.ExecuteAction(() =>
                     {
-                        response = this.CallRestService(request);
+                        response = this.CallRestService(request, out responseIntuitTid);
                     });
                 }
                 if (request != null && request.RequestUri != null && request.RequestUri.Segments != null)
@@ -189,7 +191,7 @@ namespace Intuit.Ipp.Core.Rest
             else
             {
                 // Check the response if there are any fault tags and throw appropriate exceptions.
-                IdsException exception = handler.ParseErrorResponseAndPrepareException(response);
+                IdsException exception = handler.ParseErrorResponseAndPrepareException(response, responseIntuitTid);
                 if (exception != null)
                 {
                     throw exception;
@@ -257,14 +259,16 @@ namespace Intuit.Ipp.Core.Rest
         /// Calls the rest service.
         /// </summary>
         /// <param name="request">The request.</param>
+        /// <param name="intuitTid">Outputs the intuit_tid response header, or null when not present.</param>
         /// <returns>Returns the response.</returns>
-        private string CallRestService(HttpWebRequest request)
+        private string CallRestService(HttpWebRequest request, out string intuitTid)
         {
             //if (ServicePointManager.SecurityProtocol != 0)
             //    ServicePointManager.SecurityProtocol |= SecurityProtocolType.Tls12;
             // Call the service and get response.
             using (HttpWebResponse httpWebResponse = request.GetResponse() as HttpWebResponse)
             {
+                intuitTid = ReadIntuitTid(httpWebResponse);
                 string parsedResponse = this.ParseResponse(httpWebResponse);
                 // Parse the response from the call and return.
                 if (this.context.IppConfiguration.Logger.UseVerboseLogging)
@@ -272,16 +276,28 @@ namespace Intuit.Ipp.Core.Rest
                     var responseHeaders = httpWebResponse.Headers.ConvertHeaderToString();
                     this.context.IppConfiguration.Logger.CustomLogger.Log(
                         TraceLevel.Info,
-                        "QBooks response for {Method} {RequestUri}. RealmId: {RealmId} Headers: {Headers};  Body: {Content}.",
+                        "QBooks response for {Method} {RequestUri}. RealmId: {RealmId} StatusCode: {StatusCode}; Intuit_Tid: {IntuitTid}; Headers: {Headers};  Body: {Content}.",
                         request.Method,
                         request.RequestUri,
                         this.context.RealmId,
+                        (int)httpWebResponse.StatusCode,
+                        intuitTid,
                         responseHeaders,
                         parsedResponse);
                 }
-                
+
                 return parsedResponse;
             }
+        }
+
+        /// <summary>
+        /// Reads the intuit_tid header value from the given response, or null if not present.
+        /// </summary>
+        /// <param name="response">The response.</param>
+        /// <returns>The intuit_tid header value, or null.</returns>
+        private static string ReadIntuitTid(HttpWebResponse response)
+        {
+            return response?.Headers?[FaultHandler.IntuitTidExceptionDataKey];
         }
 
         // <summary>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
@@ -386,15 +386,7 @@ namespace Intuit.Ipp.Core.Rest
                 }
 
                 // Log the response to Disk.
-                string response_intuit_tid_header = "";
-                //get intuit_tid header
-                for (int i = 0; i < httpWebResponse.Headers.Count; ++i)
-                {
-                    if (httpWebResponse.Headers.Keys[i] == "intuit_tid")
-                    {
-                        response_intuit_tid_header = httpWebResponse.Headers[i];
-                    }
-                }
+                string response_intuit_tid_header = ReadIntuitTid(httpWebResponse) ?? "";
                 this.RequestLogging.LogPlatformRequests(" Response Intuit_Tid header: " + response_intuit_tid_header + ", Response Payload: " + response, false);
                 //Log to Serilog
                 CoreHelper.AdvancedLogging.Log(" Response Intuit_Tid header: " + response_intuit_tid_header + ", Response Payload: " + response);

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/WebHeaderCollectionExtensions.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/WebHeaderCollectionExtensions.cs
@@ -22,7 +22,10 @@ public static class WebHeaderCollectionExtensions
             var splitter = i < headers.Count - 1
                 ? ";"
                 : string.Empty;
-            headersStringBuilder.Append($"{headers[i]}: {headers[headers[i]]}{splitter}");
+
+            // headers.GetKey(i) is the header name; headers.Get(i) is its value.
+            // The indexer headers[i] returns the value, not the name, so it must not be used as the key.
+            headersStringBuilder.Append($"{headers.GetKey(i)}: {headers.Get(i)}{splitter}");
         }
 
         return headersStringBuilder.ToString();

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
@@ -5,7 +5,7 @@
     <LibTargetFrameworks>net8.0</LibTargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageId>ApprovalMax.QBooks.Api</PackageId>
-    <PackageVersion>0.0.0.105</PackageVersion>
+    <PackageVersion>0.0.0.106</PackageVersion>
     <AssemblyName>ApprovalMax.QBooks.Api</AssemblyName>
     <DocumentationFile>$(BaseOutputPath)$(AssemblyName).xml</DocumentationFile>
     <DebugType>full</DebugType>


### PR DESCRIPTION
## Why

QuickBooks Online returns API faults — e.g. **error 6041** (`The uploaded filename or file extension is invalid`) on attachment upload — as **HTTP 200 OK with a Fault body**. `SyncRestHandler` already reads the `intuit_tid` response header but only writes it to the SDK's internal request/advanced logger, which is **not wired into our Serilog pipeline for most companies**.

As a result, the **Intuit transaction id is lost for failed API calls**, so when an upload fails we cannot give Intuit support a `tid` to investigate. (On the OAuth path we read the response headers ourselves, which is why `intuit_tid` shows up for token refresh but never for API/upload calls.)

## What

Attach `intuit_tid` to the thrown `IdsException` via the standard `Exception.Data["intuit_tid"]` slot, for both:

- the **200-OK fault** path (`ParseErrorResponseAndPrepareException`) — the 6041 case;
- the **WebException** path (non-200 responses), reading from `webException.Response`.

**No shared mutable state.** The tid is read locally from the `HttpWebResponse` and flows to the throw site through the call stack — via a `CallRestService(..., out string intuitTid)` out-parameter (captured by the Polly retry lambda as a local) and via `webException.Response` in the error path. A single handler instance handling concurrent requests cannot cross-contaminate tids between responses.

No public signatures change. The key is exposed as `SyncRestHandler.IntuitTidExceptionDataKey` so callers can read `exception.Data[SyncRestHandler.IntuitTidExceptionDataKey]`.

Also bumps the package version `0.0.0.105 → 0.0.0.106`.

## Consumer side

A follow-up PR in `approvalmax-product` ([#32620](https://github.com/ApprovalMax/approvalmax-product/pull/32620)) reads `exception.Data["intuit_tid"]` into `QBooksException.IntuitTid` and logs it alongside the 6041 error, so future failures carry a tid we can hand to Intuit support.

## Risk

Additive only. If the header is absent the exception is left untouched (guarded by `string.IsNullOrEmpty`).

Co-Authored-By: Claude <noreply@anthropic.com>