### PR TITLE
AM-25255 Fix missing Serilog sink deps in package (0.0.0.107)

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
@@ -5,7 +5,7 @@
     <LibTargetFrameworks>net8.0</LibTargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageId>ApprovalMax.QBooks.Api</PackageId>
-    <PackageVersion>0.0.0.106</PackageVersion>
+    <PackageVersion>0.0.0.107</PackageVersion>
     <AssemblyName>ApprovalMax.QBooks.Api</AssemblyName>
     <DocumentationFile>$(BaseOutputPath)$(AssemblyName).xml</DocumentationFile>
     <DebugType>full</DebugType>
@@ -43,6 +43,21 @@
   <ItemGroup>
     <PackageReference Include="Serilog.Extensions.Logging" />
     <PackageReference Include="Serilog.Settings.Configuration" />
+    <!--
+      The Serilog sinks/enrichers below are used at runtime by Intuit.Ipp.Diagnostics
+      (AdvancedLogging.WriteTo.Console/Debug/File/Trace + enrichers). That project is
+      packed with PrivateAssets="all", so its NuGet dependencies are NOT flowed to
+      consumers of ApprovalMax.QBooks.Api. They must be declared here so the package
+      carries them, otherwise consumers fail at load with e.g.
+      "Could not load file or assembly 'Serilog.Sinks.Debug'".
+    -->
+    <PackageReference Include="Serilog.Sinks.Console" />
+    <PackageReference Include="Serilog.Sinks.Debug" />
+    <PackageReference Include="Serilog.Sinks.File" />
+    <PackageReference Include="Serilog.Sinks.Trace" />
+    <PackageReference Include="Serilog.Enrichers.Environment" />
+    <PackageReference Include="Serilog.Enrichers.Thread" />
+    <PackageReference Include="SerilogTraceListener" />
     <PackageReference Update="Newtonsoft.Json" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" />
   </ItemGroup>


### PR DESCRIPTION
## Problem

After `ApprovalMax.QBooks.Api 0.0.0.106` was published, consumers' QBO sync broke at runtime:

```
Could not load file or assembly 'Serilog.Sinks.Debug, Version=3.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10'.
```

## Root cause

`Intuit.Ipp.Nupkg.csproj` references `Intuit.Ipp.Diagnostics` with `PrivateAssets="all"`. That project uses Serilog sinks at runtime (`AdvancedLogging.WriteTo.Console/Debug/File/Trace` + enrichers), but `PrivateAssets="all"` means **its NuGet dependencies are not flowed to consumers** of the package. The custom `CopyProjectReferencesToPackage` target only copies the project DLLs, not their package deps.

With `0.0.0.105` consumers happened to get `Serilog.Sinks.Debug` transitively from elsewhere; the `0.0.0.106` rebuild surfaced the gap. **My #14 change touched only `PackageVersion`** — it didn't cause the gap, it triggered the rebuild that exposed a pre-existing packaging defect.

## Fix

Declare the runtime Serilog sinks/enrichers (`Console`, `Debug`, `File`, `Trace`, `Enrichers.Environment`, `Enrichers.Thread`, `SerilogTraceListener`) as direct `PackageReference`s in the nupkg project, so the published package carries them as dependencies. Verified the resulting `.nuspec` now lists `Serilog.Sinks.Debug 3.0.0` etc.

Bumps `0.0.0.106 → 0.0.0.107`.

## Follow-up

Consumers (`approvalmax-product`) need a `0.0.0.106 → 0.0.0.107` bump after this publishes.

Co-Authored-By: Claude <noreply@anthropic.com>