### PR TITLE
AM-25255 Expose intuit_tid from GetResponse so upload faults can carry it

### DIFF
--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Interface/IRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/Interface/IRestHandler.cs
@@ -49,6 +49,15 @@ namespace Intuit.Ipp.Core.Rest
         string GetResponse(HttpWebRequest request);
 
         /// <summary>
+        /// Returns the response by calling REST service, additionally exposing the intuit_tid response header
+        /// so a caller that builds its own fault exception (e.g. from a 200 OK upload body) can attach it.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="intuitTid">Outputs the intuit_tid response header, or null when not available.</param>
+        /// <returns>Response from REST service.</returns>
+        string GetResponse(HttpWebRequest request, out string intuitTid);
+
+        /// <summary>
         /// Returns the response as streamn by calling REST service.
         /// </summary>
         /// <param name="request">The request.</param>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/AsyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/AsyncRestHandler.cs
@@ -154,12 +154,20 @@ namespace Intuit.Ipp.Core.Rest
         }
 
         /// <summary>
-        /// Returns the response by calling REST service. The async handler does not surface the intuit_tid
-        /// (the response is delivered through callbacks, not returned here), so it is always null.
+        /// Returns the response by calling REST service. Always outputs a null intuit_tid.
         /// </summary>
+        /// <remarks>
+        /// The async handler cannot surface the intuit_tid synchronously: this method only kicks off the
+        /// request (<c>BeginGetResponse</c>) and returns immediately, before any response exists. The response
+        /// and its headers arrive later, in the <c>AsyncExecutionCompleted</c> callback, where the intuit_tid
+        /// header is already read for logging and attached to fault exceptions via <c>FaultHandler</c>. An
+        /// <c>out</c> parameter is assigned at return time, so there is simply nothing to hand back here.
+        /// Callers that need the intuit_tid synchronously (e.g. the attachment upload path) use
+        /// <c>SyncRestHandler</c>.
+        /// </remarks>
         /// <param name="request">The request.</param>
-        /// <param name="intuitTid">Always null for the async handler.</param>
-        /// <returns>Response from REST service.</returns>
+        /// <param name="intuitTid">Always null for the async handler — see remarks.</param>
+        /// <returns>Response from REST service (null for the async handler).</returns>
         public override string GetResponse(HttpWebRequest request, out string intuitTid)
         {
             intuitTid = null;

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/AsyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/AsyncRestHandler.cs
@@ -154,6 +154,19 @@ namespace Intuit.Ipp.Core.Rest
         }
 
         /// <summary>
+        /// Returns the response by calling REST service. The async handler does not surface the intuit_tid
+        /// (the response is delivered through callbacks, not returned here), so it is always null.
+        /// </summary>
+        /// <param name="request">The request.</param>
+        /// <param name="intuitTid">Always null for the async handler.</param>
+        /// <returns>Response from REST service.</returns>
+        public override string GetResponse(HttpWebRequest request, out string intuitTid)
+        {
+            intuitTid = null;
+            return this.GetResponse(request);
+        }
+
+        /// <summary>
         /// Returns the response stream by calling REST service.
         /// </summary>
         /// <param name="request">The request.</param>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/RestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/RestHandler.cs
@@ -343,6 +343,23 @@ namespace Intuit.Ipp.Core.Rest
         public abstract string GetResponse(System.Net.HttpWebRequest request);
 
         /// <summary>
+        /// Returns the response by calling REST service, additionally exposing the intuit_tid response header.
+        /// </summary>
+        /// <remarks>
+        /// Default implementation does not surface intuit_tid; handlers that can read it (e.g.
+        /// <c>SyncRestHandler</c>) override this. Allows callers that build their own fault exception
+        /// (e.g. faults parsed from a 200 OK upload body) to attach the intuit_tid to it.
+        /// </remarks>
+        /// <param name="request">The request.</param>
+        /// <param name="intuitTid">Outputs the intuit_tid response header, or null when not available.</param>
+        /// <returns>Response from REST service.</returns>
+        public virtual string GetResponse(System.Net.HttpWebRequest request, out string intuitTid)
+        {
+            intuitTid = null;
+            return this.GetResponse(request);
+        }
+
+        /// <summary>
         /// Returns the response stream by calling REST service.
         /// </summary>
         /// <param name="request">The request.</param>

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/RestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/RestHandler.cs
@@ -343,21 +343,13 @@ namespace Intuit.Ipp.Core.Rest
         public abstract string GetResponse(System.Net.HttpWebRequest request);
 
         /// <summary>
-        /// Returns the response by calling REST service, additionally exposing the intuit_tid response header.
+        /// Returns the response by calling REST service, additionally exposing the intuit_tid response header
+        /// so a caller that builds its own fault exception (e.g. from a 200 OK upload body) can attach it.
         /// </summary>
-        /// <remarks>
-        /// Default implementation does not surface intuit_tid; handlers that can read it (e.g.
-        /// <c>SyncRestHandler</c>) override this. Allows callers that build their own fault exception
-        /// (e.g. faults parsed from a 200 OK upload body) to attach the intuit_tid to it.
-        /// </remarks>
         /// <param name="request">The request.</param>
         /// <param name="intuitTid">Outputs the intuit_tid response header, or null when not available.</param>
         /// <returns>Response from REST service.</returns>
-        public virtual string GetResponse(System.Net.HttpWebRequest request, out string intuitTid)
-        {
-            intuitTid = null;
-            return this.GetResponse(request);
-        }
+        public abstract string GetResponse(System.Net.HttpWebRequest request, out string intuitTid);
 
         /// <summary>
         /// Returns the response stream by calling REST service.

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Core/RestCalls/SyncRestHandler.cs
@@ -99,6 +99,23 @@ namespace Intuit.Ipp.Core.Rest
         /// <returns>Response from REST service.</returns>
         public override string GetResponse(HttpWebRequest request)
         {
+            return this.GetResponse(request, out _);
+        }
+
+        /// <summary>
+        /// Returns the response by calling REST service, additionally exposing the intuit_tid of the response.
+        /// </summary>
+        /// <remarks>
+        /// The standard <see cref="GetResponse(HttpWebRequest)"/> only attaches intuit_tid to exceptions it
+        /// throws itself. Callers that parse a fault out of a 200 OK body and build their own exception (e.g. the
+        /// attachment upload path) need the intuit_tid separately so they can attach it to that exception.
+        /// </remarks>
+        /// <param name="request">The request.</param>
+        /// <param name="intuitTid">Outputs the intuit_tid response header, or null when not present.</param>
+        /// <returns>Response from REST service.</returns>
+        public override string GetResponse(HttpWebRequest request, out string intuitTid)
+        {
+            intuitTid = null;
             FaultHandler handler = new FaultHandler(this.context);
 
             // Create a variable for storing the response.
@@ -197,6 +214,9 @@ namespace Intuit.Ipp.Core.Rest
                     throw exception;
                 }
             }
+
+            // Expose the intuit_tid so a caller that builds its own fault exception can attach it.
+            intuitTid = responseIntuitTid;
 
             // Return the response.
             return response;

--- a/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
+++ b/IPPDotNetDevKitCSV3/Code/Intuit.Ipp.Nupkg/Intuit.Ipp.Nupkg.csproj
@@ -5,7 +5,7 @@
     <LibTargetFrameworks>net8.0</LibTargetFrameworks>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb;.xml</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <PackageId>ApprovalMax.QBooks.Api</PackageId>
-    <PackageVersion>0.0.0.107</PackageVersion>
+    <PackageVersion>0.0.0.108</PackageVersion>
     <AssemblyName>ApprovalMax.QBooks.Api</AssemblyName>
     <DocumentationFile>$(BaseOutputPath)$(AssemblyName).xml</DocumentationFile>
     <DebugType>full</DebugType>


### PR DESCRIPTION
DRAFT — for review of the approach before wiring the backend side.

## Problem

QBO attachment uploads that fail validation (e.g. error **6041 "The uploaded filename or file extension is invalid"**) come back as a `Fault` inside an **HTTP 200** body. Our custom `DataServiceWithFixedUpload.Upload` (in approvalmax-product) parses that `Fault` itself and builds its own `ValidationException`, **bypassing** `FaultHandler.ParseErrorResponseAndPrepareException(response, intuitTid)` — the only place that attaches `intuit_tid` to the exception.

Net effect: `SyncRestHandler.GetResponse` *does* read the `intuit_tid` header (`CallRestService(out responseIntuitTid)`), but only uses it internally and returns just the body string. The upload caller never gets it, so the resulting exception has `Data["intuit_tid"]` empty → on the ApprovalMax side `QBooksException.IntuitTid` is `null` for every 6041, and we cannot report the failing call to Intuit support.

This is the missing piece of AM-25255 (the rest of the intuit_tid plumbing already landed).

## Change

Add an `out string intuitTid` overload of `GetResponse`:

- `IRestHandler` — new `GetResponse(HttpWebRequest, out string intuitTid)`.
- `RestHandler` (abstract) — declared **`abstract`** (no silent default; every handler implements it explicitly).
- `SyncRestHandler` — real `override`: existing body moved into the overload, assigning `intuitTid = responseIntuitTid` before returning; `GetResponse(request)` now delegates to `GetResponse(request, out _)`.
- `AsyncRestHandler` — delegating `override`: `intuitTid` is always `null` (the async response is delivered via callbacks, not returned here).

Existing `GetResponse(request)` behaviour is unchanged.

## Follow-up (separate PR, approvalmax-product)

`DataServiceWithFixedUpload.Upload` will call the new overload and attach the tid:

```csharp
response = this.restHandler.GetResponse(request, out var intuitTid);
...
var exception = IterateFaultAndPrepareException(fault);
if (exception is not null && !string.IsNullOrEmpty(intuitTid))
    exception.Data[FaultHandler.IntuitTidExceptionDataKey] = intuitTid;
throw exception;
```

Then `QBooksException.ExtractIntuitTid` picks it up by walking `InnerException.Data`, as it already does for `IdsException`.

## Notes

- Bump + publish `ApprovalMax.QBooks.Api` once approved, so the backend can consume the overload.
- `abstract` chosen over a `virtual` default: only two `RestHandler` subclasses exist (`SyncRestHandler`, `AsyncRestHandler`) and no standalone `IRestHandler` implementors, so the explicit contract costs just one delegating override and avoids a silent null-returning default.
- Not built locally (legacy SDK toolchain); relying on CI.